### PR TITLE
Adding auth singleton references to abstract models #17

### DIFF
--- a/gamebench_api_client/global_settings.py
+++ b/gamebench_api_client/global_settings.py
@@ -3,8 +3,8 @@
 GAMEBENCH_CONFIG = {
     'url': 'https://api.production.gamebench.net',
     'api_version': '/v1',
-    'username': '',
-    'password': '',
+    'username': 'john.smith',
+    'password': 'password',
     'company_id': '',
 }
 
@@ -18,3 +18,14 @@ def set_api_endpoint():
 
     api_endpoint = GAMEBENCH_CONFIG['url'] + GAMEBENCH_CONFIG['api_version']
     return api_endpoint
+
+
+def get_username_and_password():
+    """ Takes the username and password from global variable GAMEBENCH_CONFIG and returns it as a dictionary.
+
+    :return: user_credentials: Dictionary of key username and value password from the global variable GAMEBENCH_CONFIG
+    """
+    user_credentials = dict()
+    user_credentials['username'] = GAMEBENCH_CONFIG['username']
+    user_credentials['password'] = GAMEBENCH_CONFIG['password']
+    return user_credentials

--- a/gamebench_api_client/global_settings.py
+++ b/gamebench_api_client/global_settings.py
@@ -3,8 +3,8 @@
 GAMEBENCH_CONFIG = {
     'url': 'https://api.production.gamebench.net',
     'api_version': '/v1',
-    'username': 'john.smith',
-    'password': 'password',
+    'username': '',
+    'password': '',
     'company_id': '',
 }
 

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -22,10 +22,10 @@ class AbstractGenericModel(AbstractModel, ABC):
                 build and send a response.
         """
 
+        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
         self.mediator = GenericMediator(**request_parameters)
         self.data = self.get_data()
-        self.authenticator = Authenticator(**request_parameters)
 
     def get_data(self):
         """ Returns a Pandas DataFrame containing metric data from a response json.

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -3,6 +3,7 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import GenericMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
+from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractGenericModel(AbstractModel, ABC):
@@ -21,9 +22,9 @@ class AbstractGenericModel(AbstractModel, ABC):
             :param request_parameters: Dictionary passed in from the model Creator.  Contains information to
                 build and send a response.
         """
-
-        self.authenticator = Authenticator(**request_parameters)
+        username_and_password = get_username_and_password()
         super().__init__()
+        self.authenticator = Authenticator(username_and_password)
         self.mediator = GenericMediator(**request_parameters)
         self.data = self.get_data()
 

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 from gamebench_api_client.api.response.response_mediator import GenericMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
+from gamebench_api_client.models.authentication.authentication import Authenticator
 
 
 class AbstractGenericModel(AbstractModel, ABC):
@@ -24,6 +25,7 @@ class AbstractGenericModel(AbstractModel, ABC):
         super().__init__()
         self.mediator = GenericMediator(**request_parameters)
         self.data = self.get_data()
+        self.authenticator = Authenticator(**request_parameters)
 
     def get_data(self):
         """ Returns a Pandas DataFrame containing metric data from a response json.

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -22,10 +22,10 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
                 build and send a response.
         """
 
+        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
         self.mediator = SessionDetailMediator(**request_parameters)
         self.data = self.get_data()
-        self.authenticator = Authenticator(**request_parameters)
 
     def get_data(self):
         """ Returns a Pandas DataFrame containing metric data from a response json.

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 from gamebench_api_client.api.response.response_mediator import SessionDetailMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
+from gamebench_api_client.models.authentication.authentication import Authenticator
 
 
 class AbstractSessionDetailModel(AbstractModel, ABC):
@@ -24,6 +25,7 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
         super().__init__()
         self.mediator = SessionDetailMediator(**request_parameters)
         self.data = self.get_data()
+        self.authenticator = Authenticator(**request_parameters)
 
     def get_data(self):
         """ Returns a Pandas DataFrame containing metric data from a response json.

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -3,6 +3,7 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import SessionDetailMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
+from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractSessionDetailModel(AbstractModel, ABC):
@@ -22,8 +23,9 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        self.authenticator = Authenticator(**request_parameters)
+        username_and_password = get_username_and_password()
         super().__init__()
+        self.authenticator = Authenticator(username_and_password)
         self.mediator = SessionDetailMediator(**request_parameters)
         self.data = self.get_data()
 

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 from gamebench_api_client.api.response.response_mediator import TimeSeriesMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
+from gamebench_api_client.models.authentication.authentication import Authenticator
 
 
 class AbstractTimeSeriesModel(AbstractModel, ABC):
@@ -21,6 +22,7 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
                 build and send a response.
         """
 
+        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
         self.mediator = TimeSeriesMediator(**request_parameters)
         self.data = self.get_data()

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -3,6 +3,7 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import TimeSeriesMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
+from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractTimeSeriesModel(AbstractModel, ABC):
@@ -22,8 +23,9 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        self.authenticator = Authenticator(**request_parameters)
+        username_and_password = get_username_and_password()
         super().__init__()
+        self.authenticator = Authenticator(username_and_password)
         self.mediator = TimeSeriesMediator(**request_parameters)
         self.data = self.get_data()
 

--- a/tests/test_unit/test_global_settings.py
+++ b/tests/test_unit/test_global_settings.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from gamebench_api_client.global_settings import set_api_endpoint
+from gamebench_api_client.global_settings import set_api_endpoint, get_username_and_password
+from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestSetAPIEndpoint(TestCase):
@@ -15,3 +16,9 @@ class TestSetAPIEndpoint(TestCase):
         actual = set_api_endpoint()
         expected = 'https://api.production.gamebench.net/v1'
         self.assertEqual(actual, expected)
+
+    def test_get_username_and_password(self):
+        """ The username and password is returned as a dictionary, using values from GAMEBENCH_CONFIG."""
+        expected = {"username": GAMEBENCH_CONFIG['username'], "password": GAMEBENCH_CONFIG['password']}
+        actual = get_username_and_password()
+        self.assertEqual(expected, actual)

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from gamebench_api_client.models.dataframes.generic.abstract_generic import AbstractGenericModel
+from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestGenericFrameModel(TestCase):
@@ -23,7 +24,12 @@ class TestGenericFrameModel(TestCase):
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(**test_data)
+            mock_authenticator.assert_called_with(
+                {
+                    'username': GAMEBENCH_CONFIG['username'],
+                    'password': GAMEBENCH_CONFIG['password']
+                }
+            )
 
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_get_data(self, mock_generic_frame):

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -7,9 +7,10 @@ from gamebench_api_client.models.dataframes.generic.abstract_generic import Abst
 class TestGenericFrameModel(TestCase):
     """ Unit tests for the AbstractGenericModel class."""
 
+    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
-    def test_init_sets_attributes(self, mock_generic_frame, mock_get_data):
+    def test_init_sets_attributes(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
         test_data = {
@@ -21,6 +22,8 @@ class TestGenericFrameModel(TestCase):
             mock_generic_frame.assert_called_with(**test_data)
         with self.subTest():
             mock_get_data.assert_called_with()
+        with self.subTest():
+            mock_authenticator.assert_called_with(**test_data)
 
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_get_data(self, mock_generic_frame):
@@ -29,7 +32,9 @@ class TestGenericFrameModel(TestCase):
         expected = "Test Data"
         mock_instance = mock_generic_frame.return_value
         mock_instance.get_results.return_value = expected
-        actual = AbstractGenericModel().data
+
+        with patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator'):
+            actual = AbstractGenericModel().data
 
         self.assertEqual(
                 expected,

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from gamebench_api_client.models.dataframes.session_detail.abstract_session_detail import AbstractSessionDetailModel
+from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestSessionDetailModel(TestCase):
@@ -25,7 +26,12 @@ class TestSessionDetailModel(TestCase):
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(**test_data)
+            mock_authenticator.assert_called_with(
+                {
+                    'username': GAMEBENCH_CONFIG['username'],
+                    'password': GAMEBENCH_CONFIG['password']
+                }
+            )
 
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
     def test_get_data(self, mock_session_detail):

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -7,7 +7,7 @@ from gamebench_api_client.models.dataframes.session_detail.abstract_session_deta
 class TestSessionDetailModel(TestCase):
     """ Unit tests for the AbstractSessionDetailModel class."""
 
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
     @patch(
             'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel'
             '.get_data')
@@ -34,7 +34,9 @@ class TestSessionDetailModel(TestCase):
         expected = "Test Data"
         mock_instance = mock_session_detail.return_value
         mock_instance.get_results.return_value = expected
-        actual = AbstractSessionDetailModel().data
+
+        with patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator'):
+            actual = AbstractSessionDetailModel().data
 
         self.assertEqual(
                 expected,

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -7,11 +7,12 @@ from gamebench_api_client.models.dataframes.session_detail.abstract_session_deta
 class TestSessionDetailModel(TestCase):
     """ Unit tests for the AbstractSessionDetailModel class."""
 
+    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
     @patch(
             'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel'
             '.get_data')
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
-    def test_init_sets_attributes(self, mock_session_detail, mock_get_data):
+    def test_init_sets_attributes(self, mock_session_detail, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
         test_data = {
@@ -23,6 +24,8 @@ class TestSessionDetailModel(TestCase):
             mock_session_detail.assert_called_with(**test_data)
         with self.subTest():
             mock_get_data.assert_called_with()
+        with self.subTest():
+            mock_authenticator.assert_called_with(**test_data)
 
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
     def test_get_data(self, mock_session_detail):

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -7,9 +7,10 @@ from gamebench_api_client.models.dataframes.time_series.abstract_time_series imp
 class TestAbstractTimeSeriesModel(TestCase):
     """ Unit tests for the AbstractTimeSeriesModel class."""
 
+    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.AbstractTimeSeriesModel.get_data')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
-    def test_init_sets_attributes(self, mock_time_series, mock_get_data):
+    def test_init_sets_attributes(self, mock_time_series, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
         test_data = {
@@ -21,6 +22,8 @@ class TestAbstractTimeSeriesModel(TestCase):
             mock_time_series.assert_called_with(**test_data)
         with self.subTest():
             mock_get_data.assert_called_with()
+        with self.subTest():
+            mock_authenticator.assert_called_with(**test_data)
 
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
     def test_get_data(self, mock_time_series):
@@ -29,7 +32,9 @@ class TestAbstractTimeSeriesModel(TestCase):
         expected = "Test Data"
         mock_instance = mock_time_series.return_value
         mock_instance.get_results.return_value = expected
-        actual = AbstractTimeSeriesModel().data
+
+        with patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator'):
+            actual = AbstractTimeSeriesModel().data
 
         self.assertEqual(
                 expected,

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from gamebench_api_client.models.dataframes.time_series.abstract_time_series import AbstractTimeSeriesModel
+from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestAbstractTimeSeriesModel(TestCase):
@@ -23,7 +24,12 @@ class TestAbstractTimeSeriesModel(TestCase):
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(**test_data)
+            mock_authenticator.assert_called_with(
+                {
+                    'username': GAMEBENCH_CONFIG['username'],
+                    'password': GAMEBENCH_CONFIG['password']
+                }
+            )
 
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
     def test_get_data(self, mock_time_series):


### PR DESCRIPTION
For each of the abstract DataFrame models, there is now a reference to the Authenticator Singleton as 'authenticator'.