### PR TITLE
Add auth token to request dictionary #16

### DIFF
--- a/gamebench_api_client/api/requests_retriever/builder/request_director.py
+++ b/gamebench_api_client/api/requests_retriever/builder/request_director.py
@@ -23,8 +23,6 @@ class RequestDirector:
         """ Constructs a Request objects.
 
             :param builder: object which determines which concrete creator to use.
-            :param request_parameters: dictionary used for adding necessary
-                data to the set methods.
         """
 
         self._url_director = self._loader.set_url_director()
@@ -40,9 +38,6 @@ class RequestDirector:
         """ Constructs an authorization request object and returns the properties
             as a dictionary.
 
-            :param request_parameters: User credentials required for generating an auth token:
-                username - GameBench account username.
-                password - GameBench account password.
             :return: request - dictionary containing each element of the auth request.
         """
 
@@ -80,16 +75,6 @@ class RequestDirector:
     def get_session_request(self):
         """ Constructs and returns a session request object.
 
-            :param request_parameters:
-                session_id - id for the current session
-                metric - specific category of data being requested
-                (cpu, gpu, battery, etc.)
-                auth_token - authorization token necessary for retrieving
-                data.
-                params - parameters appended to certain session requests
-                (pageSize, timePushed, etc.)
-                data - json body appended to certain session requests
-                (example: {"apps" : [], "devices" : [], "manufacturers" : []})
             :return: request - dictionary containing each element of the session request.
         """
 

--- a/gamebench_api_client/models/abstract_model.py
+++ b/gamebench_api_client/models/abstract_model.py
@@ -7,6 +7,7 @@ class AbstractModel(ABC):
     def __init__(self, **request_parameters):
         """ Sets up the mediator and data attributes."""
 
+        self.request_parameters = request_parameters
         self.mediator = None
         self.data = None
 

--- a/gamebench_api_client/models/authentication/authentication.py
+++ b/gamebench_api_client/models/authentication/authentication.py
@@ -5,6 +5,7 @@
 """
 
 from gamebench_api_client.api.response.response_mediator import AuthenticationMediator
+from gamebench_api_client.global_settings import get_username_and_password
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.singleton import Singleton
 
@@ -12,17 +13,17 @@ from gamebench_api_client.singleton import Singleton
 class Authenticator(AbstractModel, Singleton):
     """ Class responsible for obtaining an authentication token."""
 
-    def __init__(self, **request_parameters):
+    def __init__(self):
         """ Sets up the mediator and data attributes.
 
             The mediator is set to the mediator that it will be contacting.  The data
             is the return from the get_token method.
 
-            :param request_parameters: Dictionary containing the client's username and password.
         """
 
         super().__init__()
-        self.mediator = AuthenticationMediator(**request_parameters)
+        username_and_password = get_username_and_password()
+        self.mediator = AuthenticationMediator(**username_and_password)
         self.data = self.get_data()
         self.token = self.get_data
 

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -12,19 +12,16 @@ class AbstractGenericModel(AbstractModel, ABC):
         individually as needed.
     """
 
-    def __init__(self, **request_parameters):
+    def __init__(self):
         """ Sets up the mediator and data attributes.
 
             The mediator is set to the mediator that it will be contacting.  The data
             is set to the DataFrame returned from the get_results method.
 
-            :param request_parameters: Dictionary passed in from the model Creator.  Contains information to
-                build and send a response.
         """
 
         super().__init__()
         self.authenticator = Authenticator()
-        self.request_parameters = request_parameters
         self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = GenericMediator(**self.request_parameters)
         self.data = self.get_data()

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -3,7 +3,6 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import GenericMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
-from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractGenericModel(AbstractModel, ABC):
@@ -23,9 +22,8 @@ class AbstractGenericModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        username_and_password = get_username_and_password()
         super().__init__()
-        self.authenticator = Authenticator(**username_and_password)
+        self.authenticator = Authenticator()
         self.request_parameters = request_parameters
         self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = GenericMediator(**self.request_parameters)

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -23,10 +23,10 @@ class AbstractGenericModel(AbstractModel, ABC):
         """
 
         super().__init__()
-        self.authenticator = Authenticator(**request_parameters)
         self.request_parameters = request_parameters
+        self.authenticator = Authenticator(**self.request_parameters)
         self.request_parameters['auth_token'] = self.authenticator.data['token']
-        self.mediator = GenericMediator(self.request_parameters)
+        self.mediator = GenericMediator(**self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -25,9 +25,8 @@ class AbstractGenericModel(AbstractModel, ABC):
 
         username_and_password = get_username_and_password()
         super().__init__()
-        self.authenticator = Authenticator(username_and_password)
+        self.authenticator = Authenticator(**username_and_password)
         self.request_parameters = request_parameters
-        self.authenticator = Authenticator(**self.request_parameters)
         self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = GenericMediator(**self.request_parameters)
         self.data = self.get_data()

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -25,6 +25,7 @@ class AbstractGenericModel(AbstractModel, ABC):
         super().__init__()
         self.authenticator = Authenticator(**request_parameters)
         self.request_parameters = request_parameters
+        self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = GenericMediator(self.request_parameters)
         self.data = self.get_data()
 

--- a/gamebench_api_client/models/dataframes/generic/abstract_generic.py
+++ b/gamebench_api_client/models/dataframes/generic/abstract_generic.py
@@ -22,9 +22,10 @@ class AbstractGenericModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
-        self.mediator = GenericMediator(**request_parameters)
+        self.authenticator = Authenticator(**request_parameters)
+        self.request_parameters = request_parameters
+        self.mediator = GenericMediator(self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -22,10 +22,10 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
                 build and send a response.
         """
 
+        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
         self.mediator = SessionDetailMediator(**request_parameters)
         self.data = self.get_data()
-        self.authenticator = Authenticator(**request_parameters)
 
     def get_data(self):
         """ Returns a Pandas DataFrame containing metric data from a response json.

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -22,9 +22,10 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
-        self.mediator = SessionDetailMediator(**request_parameters)
+        self.authenticator = Authenticator(**request_parameters)
+        self.request_parameters = request_parameters
+        self.mediator = SessionDetailMediator(self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -12,19 +12,16 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
         individually as needed.
     """
 
-    def __init__(self, **request_parameters):
+    def __init__(self):
         """ Sets up the mediator and data attributes.
 
             The mediator is set to the mediator that it will be contacting.  The data
             is set to the DataFrame returned from the get_results method.
 
-            :param request_parameters: Dictionary passed in from the model Creator.  Contains information to
-                build and send a response.
         """
 
         super().__init__()
         self.authenticator = Authenticator()
-        self.request_parameters = request_parameters
         self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = SessionDetailMediator(**self.request_parameters)
         self.data = self.get_data()

--- a/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
+++ b/gamebench_api_client/models/dataframes/session_detail/abstract_session_detail.py
@@ -3,7 +3,6 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import SessionDetailMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
-from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractSessionDetailModel(AbstractModel, ABC):
@@ -23,11 +22,11 @@ class AbstractSessionDetailModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        username_and_password = get_username_and_password()
         super().__init__()
-        self.authenticator = Authenticator(username_and_password)
+        self.authenticator = Authenticator()
         self.request_parameters = request_parameters
-        self.mediator = SessionDetailMediator(self.request_parameters)
+        self.request_parameters['auth_token'] = self.authenticator.data['token']
+        self.mediator = SessionDetailMediator(**self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -3,7 +3,6 @@ from abc import ABC
 from gamebench_api_client.api.response.response_mediator import TimeSeriesMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
 from gamebench_api_client.models.authentication.authentication import Authenticator
-from gamebench_api_client.global_settings import get_username_and_password
 
 
 class AbstractTimeSeriesModel(AbstractModel, ABC):
@@ -22,12 +21,12 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
             :param request_parameters: Dictionary passed in from the model Creator.  Contains information to
                 build and send a response.
         """
-        
-        username_and_password = get_username_and_password()
+
         super().__init__()
-        self.authenticator = Authenticator(username_and_password)
+        self.authenticator = Authenticator()
         self.request_parameters = request_parameters
-        self.mediator = TimeSeriesMediator(self.request_parameters)
+        self.request_parameters['auth_token'] = self.authenticator.data['token']
+        self.mediator = TimeSeriesMediator(**self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -22,9 +22,10 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
                 build and send a response.
         """
 
-        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
-        self.mediator = TimeSeriesMediator(**request_parameters)
+        self.authenticator = Authenticator(**request_parameters)
+        self.request_parameters = request_parameters
+        self.mediator = TimeSeriesMediator(self.request_parameters)
         self.data = self.get_data()
 
     def get_data(self):

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -12,19 +12,16 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
         individually as needed.
     """
 
-    def __init__(self, **request_parameters):
+    def __init__(self):
         """ Sets up the mediator and data attributes.
 
             The mediator is set to the mediator that it will be contacting.  The data
             is set to the DataFrame returned from the get_results method.
 
-            :param request_parameters: Dictionary passed in from the model Creator.  Contains information to
-                build and send a response.
         """
 
         super().__init__()
         self.authenticator = Authenticator()
-        self.request_parameters = request_parameters
         self.request_parameters['auth_token'] = self.authenticator.data['token']
         self.mediator = TimeSeriesMediator(**self.request_parameters)
         self.data = self.get_data()

--- a/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
+++ b/gamebench_api_client/models/dataframes/time_series/abstract_time_series.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 from gamebench_api_client.api.response.response_mediator import TimeSeriesMediator
 from gamebench_api_client.models.abstract_model import AbstractModel
+from gamebench_api_client.models.authentication.authentication import Authenticator
 
 
 class AbstractTimeSeriesModel(AbstractModel, ABC):
@@ -21,6 +22,7 @@ class AbstractTimeSeriesModel(AbstractModel, ABC):
                 build and send a response.
         """
 
+        self.authenticator = Authenticator(**request_parameters)
         super().__init__()
         self.mediator = TimeSeriesMediator(**request_parameters)
         self.data = self.get_data()

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -138,3 +138,5 @@ MODEL_CREATOR_IMPORT_MODULE = 'gamebench_api_client.models.creator.model_creator
                               '._import_given_model_module'
 MODEL_CREATOR_SET_MODULE = 'gamebench_api_client.models.creator.model_creator.ModelCreator._set_module_name_by_model'
 ABSTRACT_SESSION_DETAIL = 'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail'
+ABSTRACT_GENERIC = 'gamebench_api_client.models.dataframes.generic.abstract_generic'
+ABSTRACT_TIME_SERIES = 'gamebench_api_client.models.dataframes.time_series.abstract_time_series'

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -137,3 +137,4 @@ MODEL_CREATOR_GET_CLASS = 'gamebench_api_client.models.creator.model_creator.Mod
 MODEL_CREATOR_IMPORT_MODULE = 'gamebench_api_client.models.creator.model_creator.ModelCreator' \
                               '._import_given_model_module'
 MODEL_CREATOR_SET_MODULE = 'gamebench_api_client.models.creator.model_creator.ModelCreator._set_module_name_by_model'
+ABSTRACT_SESSION_DETAIL = 'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail'

--- a/tests/test_unit/test_models/test_authentication/test_authentication.py
+++ b/tests/test_unit/test_models/test_authentication/test_authentication.py
@@ -14,14 +14,10 @@ class TestAuthenticator(TestCase):
     def test_init_sets_attributes(self, mock_mediator, mock_get_data):
         """ The instance variables call the appropriate methods."""
 
-        test_data = {
-            'username': 'Testing',
-            'password': 'Blah'
-        }
-        Authenticator(**test_data)
+        Authenticator()
 
         with self.subTest():
-            mock_mediator.assert_called_with(**test_data)
+            mock_mediator.assert_called_with(password='', username='')
         with self.subTest():
             mock_get_data.assert_called_with()
 

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -17,7 +17,7 @@ class TestGenericFrameModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        generic_model = AbstractGenericModel(**test_data)
+        generic_model = AbstractGenericModel()
 
         with self.subTest():
             mock_generic_frame.assert_called_with(**generic_model.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -14,9 +14,6 @@ class TestGenericFrameModel(TestCase):
     def test_init_sets_attributes(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
-        test_data = {
-            'metric': 'Testing'
-        }
         generic_model = AbstractGenericModel()
 
         with self.subTest():
@@ -43,11 +40,8 @@ class TestGenericFrameModel(TestCase):
         )
 
     @patch(f'{ABSTRACT_GENERIC}.Authenticator')
-    @patch(f'{ABSTRACT_GENERIC}.AbstractGenericModel.get_data')
-    @patch(f'{ABSTRACT_GENERIC}.GenericMediator')
-    def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
+    def test_auth_token_added_to_request_parameters(self, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
-        starting_dict = {}
 
         expected_dict = {
             'auth_token': 'q1w2e3r4t5y6'
@@ -58,6 +52,8 @@ class TestGenericFrameModel(TestCase):
         }
         mock_authenticator.return_value = mock_dict
 
-        actual = AbstractGenericModel(**starting_dict)
+        with patch(f'{ABSTRACT_GENERIC}.GenericMediator'),\
+                patch(f'{ABSTRACT_GENERIC}.AbstractGenericModel.get_data'):
+            actual = AbstractGenericModel()
 
         self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -47,18 +47,17 @@ class TestGenericFrameModel(TestCase):
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
 
-        starting_dict = dict()
+        starting_dict = {}
 
         expected_dict = {
             'auth_token': 'q1w2e3r4t5y6'
         }
-
-        mock_authenticator.data = {
+        test = Mock()
+        test.data = {
             'token': 'q1w2e3r4t5y6'
         }
+        mock_authenticator.return_value = test
 
         actual = AbstractGenericModel(**starting_dict)
 
-        self.assertIn('auth_token', actual.request_parameters)
-        # Want this to be the test, but the value is a MagicMock object.
-        # self.assertDictEqual(expected_dict, actual.request_parameters)
+        self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -16,10 +16,10 @@ class TestGenericFrameModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        AbstractGenericModel(**test_data)
+        generic_model = AbstractGenericModel(**test_data)
 
         with self.subTest():
-            mock_generic_frame.assert_called_with(**test_data)
+            mock_generic_frame.assert_called_with(generic_model.request_parameters)
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -14,22 +14,21 @@ class TestGenericFrameModel(TestCase):
     def test_init_sets_attributes(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
+        test_auth_data = {
+            'username': GAMEBENCH_CONFIG['username'],
+            'password': GAMEBENCH_CONFIG['password']
+        }
         test_data = {
             'metric': 'Testing'
         }
         generic_model = AbstractGenericModel(**test_data)
 
         with self.subTest():
-            mock_generic_frame.assert_called_with(generic_model.request_parameters)
+            mock_generic_frame.assert_called_with(**generic_model.request_parameters)
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(
-                {
-                    'username': GAMEBENCH_CONFIG['username'],
-                    'password': GAMEBENCH_CONFIG['password']
-                }
-            )
+            mock_authenticator.assert_called_with(**test_auth_data)
 
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_get_data(self, mock_generic_frame):
@@ -43,15 +42,14 @@ class TestGenericFrameModel(TestCase):
             actual = AbstractGenericModel().data
 
         self.assertEqual(
-                expected,
-                actual
+            expected,
+            actual
         )
 
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
-
         starting_dict = {}
 
         expected_dict = {

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from gamebench_api_client.models.dataframes.generic.abstract_generic import AbstractGenericModel
+from pandas import DataFrame
 
 
 class TestGenericFrameModel(TestCase):
@@ -40,3 +41,22 @@ class TestGenericFrameModel(TestCase):
                 expected,
                 actual
         )
+
+    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
+    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
+    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
+    def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
+
+        starting_dict = dict()
+
+        expected_dict = {
+            'auth_token': 'q1w2e3r4t5y6'
+        }
+
+        mock_get_data.return_value = {
+                'token': 'q1w2e3r4t5y6'
+        }
+
+        actual_dict = AbstractGenericModel(**starting_dict)
+
+        self.assertEqual(expected_dict, actual_dict.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -2,14 +2,15 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.generic.abstract_generic import AbstractGenericModel
+from tests.fixtures.constants import ABSTRACT_GENERIC
 
 
 class TestGenericFrameModel(TestCase):
     """ Unit tests for the AbstractGenericModel class."""
 
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
+    @patch(f'{ABSTRACT_GENERIC}.Authenticator')
+    @patch(f'{ABSTRACT_GENERIC}.AbstractGenericModel.get_data')
+    @patch(f'{ABSTRACT_GENERIC}.GenericMediator')
     def test_init_sets_attributes(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
@@ -25,7 +26,7 @@ class TestGenericFrameModel(TestCase):
         with self.subTest():
             mock_authenticator.assert_called_with()
 
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
+    @patch(f'{ABSTRACT_GENERIC}.GenericMediator')
     def test_get_data(self, mock_generic_frame):
         """ Verify the data is properly set."""
 
@@ -33,7 +34,7 @@ class TestGenericFrameModel(TestCase):
         mock_instance = mock_generic_frame.return_value
         mock_instance.get_results.return_value = expected
 
-        with patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator'):
+        with patch(f'{ABSTRACT_GENERIC}.Authenticator'):
             actual = AbstractGenericModel().data
 
         self.assertEqual(
@@ -41,9 +42,9 @@ class TestGenericFrameModel(TestCase):
             actual
         )
 
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
+    @patch(f'{ABSTRACT_GENERIC}.Authenticator')
+    @patch(f'{ABSTRACT_GENERIC}.AbstractGenericModel.get_data')
+    @patch(f'{ABSTRACT_GENERIC}.GenericMediator')
     def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.generic.abstract_generic import AbstractGenericModel
-from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestGenericFrameModel(TestCase):
@@ -14,10 +13,6 @@ class TestGenericFrameModel(TestCase):
     def test_init_sets_attributes(self, mock_generic_frame, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
-        test_auth_data = {
-            'username': GAMEBENCH_CONFIG['username'],
-            'password': GAMEBENCH_CONFIG['password']
-        }
         test_data = {
             'metric': 'Testing'
         }
@@ -28,7 +23,7 @@ class TestGenericFrameModel(TestCase):
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(**test_auth_data)
+            mock_authenticator.assert_called_with()
 
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_get_data(self, mock_generic_frame):
@@ -50,16 +45,17 @@ class TestGenericFrameModel(TestCase):
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.AbstractGenericModel.get_data')
     @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.GenericMediator')
     def test_auth_token_added_to_request_parameters(self, mock_generic_frame, mock_get_data, mock_authenticator):
+        """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}
 
         expected_dict = {
             'auth_token': 'q1w2e3r4t5y6'
         }
-        test = Mock()
-        test.data = {
+        mock_dict = Mock()
+        mock_dict.data = {
             'token': 'q1w2e3r4t5y6'
         }
-        mock_authenticator.return_value = test
+        mock_authenticator.return_value = mock_dict
 
         actual = AbstractGenericModel(**starting_dict)
 

--- a/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
+++ b/tests/test_unit/test_models/test_dataframes/test_generic/test_abstract_generic.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.generic.abstract_generic import AbstractGenericModel
 from pandas import DataFrame
@@ -53,10 +53,12 @@ class TestGenericFrameModel(TestCase):
             'auth_token': 'q1w2e3r4t5y6'
         }
 
-        mock_get_data.return_value = {
-                'token': 'q1w2e3r4t5y6'
+        mock_authenticator.data = {
+            'token': 'q1w2e3r4t5y6'
         }
 
-        actual_dict = AbstractGenericModel(**starting_dict)
+        actual = AbstractGenericModel(**starting_dict)
 
-        self.assertEqual(expected_dict, actual_dict.request_parameters)
+        self.assertIn('auth_token', actual.request_parameters)
+        # Want this to be the test, but the value is a MagicMock object.
+        # self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -7,7 +7,7 @@ from gamebench_api_client.models.dataframes.session_detail.abstract_session_deta
 class TestSessionDetailModel(TestCase):
     """ Unit tests for the AbstractSessionDetailModel class."""
 
-    @patch('gamebench_api_client.models.dataframes.generic.abstract_generic.Authenticator')
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
     @patch(
             'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel'
             '.get_data')
@@ -34,7 +34,9 @@ class TestSessionDetailModel(TestCase):
         expected = "Test Data"
         mock_instance = mock_session_detail.return_value
         mock_instance.get_results.return_value = expected
-        actual = AbstractSessionDetailModel().data
+
+        with patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator'):
+            actual = AbstractSessionDetailModel().data
 
         self.assertEqual(
                 expected,

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -14,9 +14,6 @@ class TestSessionDetailModel(TestCase):
     def test_init_sets_attributes(self, mock_session_detail, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
-        test_data = {
-            'metric': 'Testing'
-        }
         session_detail_model = AbstractSessionDetailModel()
 
         with self.subTest():
@@ -43,11 +40,8 @@ class TestSessionDetailModel(TestCase):
         )
 
     @patch(f'{ABSTRACT_SESSION_DETAIL}.Authenticator')
-    @patch(f'{ABSTRACT_SESSION_DETAIL}.AbstractSessionDetailModel.get_data')
-    @patch(f'{ABSTRACT_SESSION_DETAIL}.SessionDetailMediator')
-    def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
+    def test_auth_token_added_to_request_parameters(self, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
-        starting_dict = {}
 
         expected_dict = {
             'auth_token': 'q1w2e3r4t5y6'
@@ -58,6 +52,8 @@ class TestSessionDetailModel(TestCase):
         }
         mock_authenticator.return_value = mock_dict
 
-        actual = AbstractSessionDetailModel(**starting_dict)
+        with patch(f'{ABSTRACT_SESSION_DETAIL}.SessionDetailMediator'), \
+                patch(f'{ABSTRACT_SESSION_DETAIL}.AbstractSessionDetailModel.get_data'):
+            actual = AbstractSessionDetailModel()
 
         self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -44,9 +44,10 @@ class TestSessionDetailModel(TestCase):
         )
 
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel.get_data')
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.' +
+           'AbstractSessionDetailModel.get_data')
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
-    def test_auth_token_added_to_request_parameters(self, mock_session_detail_mediator, mock_get_data, mock_authenticator):
+    def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}
 

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -18,10 +18,10 @@ class TestSessionDetailModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        AbstractSessionDetailModel(**test_data)
+        session_detail_model = AbstractSessionDetailModel(**test_data)
 
         with self.subTest():
-            mock_session_detail.assert_called_with(**test_data)
+            mock_session_detail.assert_called_with(session_detail_model.request_parameters)
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.session_detail.abstract_session_detail import AbstractSessionDetailModel
-from gamebench_api_client.global_settings import GAMEBENCH_CONFIG
 
 
 class TestSessionDetailModel(TestCase):
@@ -22,16 +21,11 @@ class TestSessionDetailModel(TestCase):
         session_detail_model = AbstractSessionDetailModel(**test_data)
 
         with self.subTest():
-            mock_session_detail.assert_called_with(session_detail_model.request_parameters)
+            mock_session_detail.assert_called_with(**session_detail_model.request_parameters)
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():
-            mock_authenticator.assert_called_with(
-                {
-                    'username': GAMEBENCH_CONFIG['username'],
-                    'password': GAMEBENCH_CONFIG['password']
-                }
-            )
+            mock_authenticator.assert_called_with()
 
     @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
     def test_get_data(self, mock_session_detail):
@@ -48,3 +42,23 @@ class TestSessionDetailModel(TestCase):
                 expected,
                 actual
         )
+
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel.get_data')
+    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
+    def test_auth_token_added_to_request_parameters(self, mock_session_detail_mediator, mock_get_data, mock_authenticator):
+        """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
+        starting_dict = {}
+
+        expected_dict = {
+            'auth_token': 'q1w2e3r4t5y6'
+        }
+        mock_dict = Mock()
+        mock_dict.data = {
+            'token': 'q1w2e3r4t5y6'
+        }
+        mock_authenticator.return_value = mock_dict
+
+        actual = AbstractSessionDetailModel(**starting_dict)
+
+        self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -2,16 +2,15 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.session_detail.abstract_session_detail import AbstractSessionDetailModel
+from tests.fixtures.constants import ABSTRACT_SESSION_DETAIL
 
 
 class TestSessionDetailModel(TestCase):
     """ Unit tests for the AbstractSessionDetailModel class."""
 
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
-    @patch(
-            'gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.AbstractSessionDetailModel'
-            '.get_data')
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.Authenticator')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.AbstractSessionDetailModel.get_data')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.SessionDetailMediator')
     def test_init_sets_attributes(self, mock_session_detail, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
@@ -27,7 +26,7 @@ class TestSessionDetailModel(TestCase):
         with self.subTest():
             mock_authenticator.assert_called_with()
 
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.SessionDetailMediator')
     def test_get_data(self, mock_session_detail):
         """ Verify the data is properly set."""
 
@@ -35,7 +34,7 @@ class TestSessionDetailModel(TestCase):
         mock_instance = mock_session_detail.return_value
         mock_instance.get_results.return_value = expected
 
-        with patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator'):
+        with patch(f'{ABSTRACT_SESSION_DETAIL}.Authenticator'):
             actual = AbstractSessionDetailModel().data
 
         self.assertEqual(
@@ -43,10 +42,9 @@ class TestSessionDetailModel(TestCase):
                 actual
         )
 
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.' +
-           'AbstractSessionDetailModel.get_data')
-    @patch('gamebench_api_client.models.dataframes.session_detail.abstract_session_detail.SessionDetailMediator')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.Authenticator')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.AbstractSessionDetailModel.get_data')
+    @patch(f'{ABSTRACT_SESSION_DETAIL}.SessionDetailMediator')
     def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}

--- a/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
+++ b/tests/test_unit/test_models/test_dataframes/test_session_detail/test_abstract_session_detail.py
@@ -17,7 +17,7 @@ class TestSessionDetailModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        session_detail_model = AbstractSessionDetailModel(**test_data)
+        session_detail_model = AbstractSessionDetailModel()
 
         with self.subTest():
             mock_session_detail.assert_called_with(**session_detail_model.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -7,9 +7,10 @@ from gamebench_api_client.models.dataframes.time_series.abstract_time_series imp
 class TestAbstractTimeSeriesModel(TestCase):
     """ Unit tests for the AbstractTimeSeriesModel class."""
 
+    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.AbstractTimeSeriesModel.get_data')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
-    def test_init_sets_attributes(self, mock_time_series, mock_get_data):
+    def test_init_sets_attributes(self, mock_time_series, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
         test_data = {
@@ -21,6 +22,8 @@ class TestAbstractTimeSeriesModel(TestCase):
             mock_time_series.assert_called_with(**test_data)
         with self.subTest():
             mock_get_data.assert_called_with()
+        with self.subTest():
+            mock_authenticator.assert_called_with(**test_data)
 
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
     def test_get_data(self, mock_time_series):
@@ -29,7 +32,9 @@ class TestAbstractTimeSeriesModel(TestCase):
         expected = "Test Data"
         mock_instance = mock_time_series.return_value
         mock_instance.get_results.return_value = expected
-        actual = AbstractTimeSeriesModel().data
+
+        with patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator'):
+            actual = AbstractTimeSeriesModel().data
 
         self.assertEqual(
                 expected,

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -16,10 +16,10 @@ class TestAbstractTimeSeriesModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        AbstractTimeSeriesModel(**test_data)
+        time_series_model = AbstractTimeSeriesModel(**test_data)
 
         with self.subTest():
-            mock_time_series.assert_called_with(**test_data)
+            mock_time_series.assert_called_with(time_series_model.request_parameters)
         with self.subTest():
             mock_get_data.assert_called_with()
         with self.subTest():

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -14,9 +14,6 @@ class TestAbstractTimeSeriesModel(TestCase):
     def test_init_sets_attributes(self, mock_time_series, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
-        test_data = {
-            'metric': 'Testing'
-        }
         time_series_model = AbstractTimeSeriesModel()
 
         with self.subTest():
@@ -43,11 +40,8 @@ class TestAbstractTimeSeriesModel(TestCase):
         )
 
     @patch(f'{ABSTRACT_TIME_SERIES}.Authenticator')
-    @patch(f'{ABSTRACT_TIME_SERIES}.AbstractTimeSeriesModel.get_data')
-    @patch(f'{ABSTRACT_TIME_SERIES}.TimeSeriesMediator')
-    def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
+    def test_auth_token_added_to_request_parameters(self, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
-        starting_dict = {}
 
         expected_dict = {
             'auth_token': 'q1w2e3r4t5y6'
@@ -58,6 +52,8 @@ class TestAbstractTimeSeriesModel(TestCase):
         }
         mock_authenticator.return_value = mock_dict
 
-        actual = AbstractTimeSeriesModel(**starting_dict)
+        with patch(f'{ABSTRACT_TIME_SERIES}.TimeSeriesMediator'), \
+                patch(f'{ABSTRACT_TIME_SERIES}.AbstractTimeSeriesModel.get_data'):
+            actual = AbstractTimeSeriesModel()
 
         self.assertDictEqual(expected_dict, actual.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -17,7 +17,7 @@ class TestAbstractTimeSeriesModel(TestCase):
         test_data = {
             'metric': 'Testing'
         }
-        time_series_model = AbstractTimeSeriesModel(**test_data)
+        time_series_model = AbstractTimeSeriesModel()
 
         with self.subTest():
             mock_time_series.assert_called_with(**time_series_model.request_parameters)

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -2,14 +2,15 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from gamebench_api_client.models.dataframes.time_series.abstract_time_series import AbstractTimeSeriesModel
+from tests.fixtures.constants import ABSTRACT_TIME_SERIES
 
 
 class TestAbstractTimeSeriesModel(TestCase):
     """ Unit tests for the AbstractTimeSeriesModel class."""
 
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.AbstractTimeSeriesModel.get_data')
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
+    @patch(f'{ABSTRACT_TIME_SERIES}.Authenticator')
+    @patch(f'{ABSTRACT_TIME_SERIES}.AbstractTimeSeriesModel.get_data')
+    @patch(f'{ABSTRACT_TIME_SERIES}.TimeSeriesMediator')
     def test_init_sets_attributes(self, mock_time_series, mock_get_data, mock_authenticator):
         """ Verify the instance variables call the appropriate methods."""
 
@@ -25,7 +26,7 @@ class TestAbstractTimeSeriesModel(TestCase):
         with self.subTest():
             mock_authenticator.assert_called_with()
 
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
+    @patch(f'{ABSTRACT_TIME_SERIES}.TimeSeriesMediator')
     def test_get_data(self, mock_time_series):
         """ Verify the data is properly set."""
 
@@ -33,7 +34,7 @@ class TestAbstractTimeSeriesModel(TestCase):
         mock_instance = mock_time_series.return_value
         mock_instance.get_results.return_value = expected
 
-        with patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator'):
+        with patch(f'{ABSTRACT_TIME_SERIES}.Authenticator'):
             actual = AbstractTimeSeriesModel().data
 
         self.assertEqual(
@@ -41,9 +42,9 @@ class TestAbstractTimeSeriesModel(TestCase):
                 actual
         )
 
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator')
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.AbstractTimeSeriesModel.get_data')
-    @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
+    @patch(f'{ABSTRACT_TIME_SERIES}.Authenticator')
+    @patch(f'{ABSTRACT_TIME_SERIES}.AbstractTimeSeriesModel.get_data')
+    @patch(f'{ABSTRACT_TIME_SERIES}.TimeSeriesMediator')
     def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}

--- a/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
+++ b/tests/test_unit/test_models/test_dataframes/test_time_series/test_abstract_time_series.py
@@ -44,7 +44,7 @@ class TestAbstractTimeSeriesModel(TestCase):
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.Authenticator')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.AbstractTimeSeriesModel.get_data')
     @patch('gamebench_api_client.models.dataframes.time_series.abstract_time_series.TimeSeriesMediator')
-    def test_auth_token_added_to_request_parameters(self, mock_session_detail_mediator, mock_get_data, mock_authenticator):
+    def test_auth_token_added_to_request_parameters(self, mock_session_mediator, mock_get_data, mock_authenticator):
         """ Ensure that the Authenticator token is added to the request_parameters dictionary as 'auth_token'."""
         starting_dict = {}
 


### PR DESCRIPTION
Abstract dataframe classes are now adding an entry to the request_parameters dict with key 'auth_token' and value authenticator.data['token'].

Included in this branch is a refactor to remove Authenticator params, and making the username and password getter method call within the Authenticator.