### PR TITLE
Fix implemented to URLBuilder

### DIFF
--- a/gamebench_api_client/api/requests_retriever/builder/url/url_builder.py
+++ b/gamebench_api_client/api/requests_retriever/builder/url/url_builder.py
@@ -81,9 +81,16 @@ class SessionURL(URLBuilder):
         self.url = self._build_url()
 
     def _set_session_id(self, session_id):
-        """ Helper method to set the session_id. """
+        """ Helper method to set the session_id.
 
-        if session_id != '':
+            If the session_id contains an id it will set the self.session_id variable
+            to the given id and a '/' in front of it.  The forward slash is necessary
+            for when the id is added onto the end of a URL.
+
+            :param session_id: The session_id for a request.
+        """
+
+        if session_id:
             self.session_id = '/' + session_id
         else:
             self.session_id = session_id

--- a/gamebench_api_client/api/requests_retriever/builder/url/url_builder.py
+++ b/gamebench_api_client/api/requests_retriever/builder/url/url_builder.py
@@ -83,7 +83,10 @@ class SessionURL(URLBuilder):
     def _set_session_id(self, session_id):
         """ Helper method to set the session_id. """
 
-        self.session_id = session_id
+        if session_id != '':
+            self.session_id = '/' + session_id
+        else:
+            self.session_id = session_id
 
     def _set_metric(self, metric):
         """ Helper method to set the session metric. """

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -33,11 +33,11 @@ AUTH_ATTRIBUTES = {
 
 # Session Related
 SESSION_SUFFIX = '/sessions'
-SESSION_ID = "/session_id"
+SESSION_ID = "session_id"
 METRIC = "/cpu"
-BASE_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + SESSION_ID
-DEFAULT_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + SESSION_ID + METRIC
-GENERIC_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + SESSION_ID + '/notes'
+BASE_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + '/' + SESSION_ID
+DEFAULT_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + '/' + SESSION_ID + METRIC
+GENERIC_SESSION_URL = BASE_URL + VERSION + SESSION_SUFFIX + '/' + SESSION_ID + '/notes'
 SESSION_DATA = {
     "data": {
         "test_data": "test_data"
@@ -73,12 +73,6 @@ SAMPLE_RESPONSE = {
     ]
 }
 METRIC_TEST_PARAMS = {
-    "no_metric": {
-        "metric": "",
-        "headers": NO_METRIC_HEADERS,
-        "method": "POST",
-        "session_id": ""
-    },
     "metric_present": {
         "metric": METRIC,
         "headers": DEFAULT_SESSION_HEADERS,

--- a/tests/test_integration/test_api/test_requests_retriever/test_builder/test_request_director.py
+++ b/tests/test_integration/test_api/test_requests_retriever/test_builder/test_request_director.py
@@ -60,7 +60,7 @@ class TestGetAuthRequest(TestCase):
             }
             expected = {
                 "method": params["method"],
-                "url": BASE_URL + VERSION + SESSION_SUFFIX + params["session_id"] + params["metric"],
+                "url": BASE_URL + VERSION + SESSION_SUFFIX + '/' + params["session_id"] + params["metric"],
                 "attributes": {
                     "headers": params["headers"],
                     "params": "test_params",
@@ -82,3 +82,37 @@ class TestGetAuthRequest(TestCase):
                     actual
                 )
             )
+
+    def test_get_session_request_no_metric(self):
+        """ Test to check that get_session_request returns expected dict when session_id is empty."""
+
+        test_params = {
+            'method': 'POST',
+            'session_id': '',
+            'metric': '',
+            'auth_token': AUTH_TOKEN,
+            "params": "test_params",
+            "data": {
+                "test_data": "test_data"
+            }
+        }
+
+        expected = {
+            "method": "POST",
+            "url": BASE_URL + VERSION + SESSION_SUFFIX,
+            "attributes": {
+                "headers": NO_METRIC_HEADERS,
+                "params": "test_params",
+                "data": {
+                    "test_data": "test_data"
+                }
+            }
+        }
+
+        self.director = RequestDirector(**test_params)
+        actual = self.director.get_session_request()
+
+        self.assertEqual(
+            expected,
+            actual,
+        )

--- a/tests/test_integration/test_models/test_creator/test_model_creator.py
+++ b/tests/test_integration/test_models/test_creator/test_model_creator.py
@@ -43,7 +43,6 @@ class TestModelCreator(TestCase):
             ['id', 'sessionId']
         )
         actual = model.data
-
         assert_frame_equal(actual, expected)
 
     @requests_mock.Mocker()

--- a/tests/test_unit/test_api/test_requests_retriever/test_builder/request_url/test_url_builder.py
+++ b/tests/test_unit/test_api/test_requests_retriever/test_builder/request_url/test_url_builder.py
@@ -122,7 +122,7 @@ class TestSessionURL(TestCase):
         self.session.base_url = BASE_URL
         self.session.version = VERSION
         self.session.suffix = SESSION_SUFFIX
-        self.session.session_id = SESSION_ID
+        self.session.session_id = '/' + SESSION_ID
         self.session.metric = METRIC
         actual = self.session._build_url()
 
@@ -133,7 +133,16 @@ class TestSessionURL(TestCase):
 
         self.session._set_session_id(SESSION_ID)
         actual = self.session.session_id
-        self.assertEqual(actual, SESSION_ID)
+        expected = '/' + SESSION_ID
+        self.assertEqual(actual, expected)
+
+    def test_set_session_id_with_empty_session(self):
+        """ Session ID is blank."""
+
+        self.session._set_session_id('')
+        actual = self.session.session_id
+        expected = ''
+        self.assertEqual(actual, expected)
 
     def test_set_metric(self):
         """ Verify the metric is set."""


### PR DESCRIPTION
The URL Builder wasn't adding a '/' in front of the session_id, so the client was required to do this.  Since we don't want that responsibility on the client logic was put in to add the '/'.